### PR TITLE
Fix "open static" problem in Swift 5

### DIFF
--- a/Source/Navajo.swift
+++ b/Source/Navajo.swift
@@ -48,7 +48,7 @@ open class Navajo {
     /// - parameter password: Password string to be calculated
     ///
     /// - returns: Level of strength in NJOPasswordStrength
-    open static func strength(ofPassword password: String) -> PasswordStrength {
+    public static func strength(ofPassword password: String) -> PasswordStrength {
         return passwordStrength(forEntropy: entropy(of: password))
     }
 
@@ -57,7 +57,7 @@ open class Navajo {
     /// - parameter strength: NJOPasswordStrength to be converted
     ///
     /// - returns: Localized string
-    open static func localizedString(forStrength strength: PasswordStrength) -> String {
+    public static func localizedString(forStrength strength: PasswordStrength) -> String {
         switch strength {
         case .veryWeak:
             return NSLocalizedString("NAVAJO_VERY_WEAK", tableName: nil, bundle: Bundle.main, value: "Very Weak", comment: "Navajo - Very weak")

--- a/Source/PasswordValidator.swift
+++ b/Source/PasswordValidator.swift
@@ -31,12 +31,12 @@ open class PasswordValidator {
     open var rules: [PasswordRule] = []
 
     /// PasswordValidator object which checks if the length of password is between 6 and 24.
-    open static var standard: PasswordValidator {
+    public static var standard: PasswordValidator {
         return PasswordValidator(rules: [standardLengthRule])
     }
 
     /// Length rule having minimum of 6 and maximum of 24.
-    open static var standardLengthRule: LengthRule {
+    public static var standardLengthRule: LengthRule {
         return LengthRule(min: 6, max: 24)
     }
 


### PR DESCRIPTION
In Swift 5 "open static" declarations get the error message: "static declarations are implicitly 'final'; use 'public' instead of 'open'".  So update the offending declarations to "public".