### PR TITLE
Update RegularExpressionRule match logic

### DIFF
--- a/Source/RegularExpressionRule.swift
+++ b/Source/RegularExpressionRule.swift
@@ -42,7 +42,9 @@ open class RegularExpressionRule: PasswordRule {
             return false
         }
 
-        return regularExpression.numberOfMatches(in: password, options: [], range: NSMakeRange(0, password.count)) > 0
+        let isMatched = regularExpression.numberOfMatches(in: password, options: [], range: NSMakeRange(0, password.count)) > 0
+        
+        return !isMatched
     }
 
     /// Error description.


### PR DESCRIPTION
There's a bug when we do `evaluate`. If it's matched, it should return `false`.